### PR TITLE
Remove primes from foreign modules exports

### DIFF
--- a/src/React/Basic/DOM.js
+++ b/src/React/Basic/DOM.js
@@ -2,10 +2,10 @@
 
 const ReactDOM = require("react-dom");
 
-exports["render'"] = (jsx) => (node) => (callback) => () =>
+exports.renderThen = (jsx) => (node) => (callback) => () =>
   ReactDOM.render(jsx, node, callback);
 
-exports["hydrate'"] = (jsx) => (node) => (callback) => () =>
+exports.hydrateThen = (jsx) => (node) => (callback) => () =>
   ReactDOM.hydrate(jsx, node, callback);
 
 exports.unmount = (node) => () => ReactDOM.unmountComponentAtNode(node);

--- a/src/React/Basic/DOM.purs
+++ b/src/React/Basic/DOM.purs
@@ -36,7 +36,10 @@ render jsx node = render' jsx node (pure unit)
 -- | DOM update is complete.
 -- |
 -- | __*Note:* Relies on `ReactDOM.render`__
-foreign import render' :: JSX -> Element -> Effect Unit -> Effect Unit
+render' :: JSX -> Element -> Effect Unit -> Effect Unit
+render' = renderThen
+
+foreign import renderThen :: JSX -> Element -> Effect Unit -> Effect Unit
 
 -- | Render or update/re-render a component tree into
 -- | a DOM element, attempting to reuse the existing
@@ -56,7 +59,10 @@ hydrate jsx node = hydrate' jsx node (pure unit)
 -- | __*Note:* Relies on `ReactDOM.hydrate`, generally only
 -- |   used with `ReactDOMServer.renderToNodeStream` or
 -- |   `ReactDOMServer.renderToString`__
-foreign import hydrate' :: JSX -> Element -> Effect Unit -> Effect Unit
+hydrate' :: JSX -> Element -> Effect Unit -> Effect Unit
+hydrate' = hydrateThen
+
+foreign import hydrateThen :: JSX -> Element -> Effect Unit -> Effect Unit
 
 -- | Attempt to unmount and clean up the React app
 -- | rendered into the given element. Returns `true`


### PR DESCRIPTION
Primes in foreign modules exports will be deprecated in v0.14.0. See https://github.com/purescript/purescript/pull/3792.