### PR TITLE
Add `renderToString` and `renderToStaticMarkup`

### DIFF
--- a/src/React/Basic/DOM/Server.js
+++ b/src/React/Basic/DOM/Server.js
@@ -1,0 +1,7 @@
+"use strict";
+
+const ReactDOMServer = require("react-dom/server");
+
+exports.renderToString = ReactDOMServer.renderToString;
+
+exports.renderToStaticMarkup = ReactDOMServer.renderToStaticMarkup;

--- a/src/React/Basic/DOM/Server.purs
+++ b/src/React/Basic/DOM/Server.purs
@@ -1,0 +1,26 @@
+module React.Basic.DOM.Server
+  ( renderToString
+  , renderToStaticMarkup
+  ) where
+
+import React.Basic (JSX)
+
+-- | Render a React element to its initial HTML. React will return an HTML string.
+-- | You can use this method to generate HTML on the server and send the markup
+-- | down on the initial request for faster page loads and to allow search engines
+-- | to crawl your pages for SEO purposes.
+-- |
+-- | If you call `ReactDOM.hydrate` on a node that already has this server-rendered
+-- | markup, React will preserve it and only attach event handlers, allowing you to
+-- | have a very performant first-load experience.
+foreign import renderToString :: JSX -> String
+
+-- | Similar to `renderToString`, except this doesn’t create extra DOM attributes
+-- | that React uses internally, such as `data-reactroot`. This is useful if you
+-- | want to use React as a simple static page generator, as stripping away the
+-- | extra attributes can save some bytes.
+-- |
+-- | If you plan to use React on the client to make the markup interactive, do not
+-- | use this method. Instead, use `renderToString` on the server and `ReactDOM.hydrate`
+-- | on the client.
+foreign import renderToStaticMarkup :: JSX -> String


### PR DESCRIPTION
This PR adds support for the following `ReactDOMServer` methods:
- `renderToString`
- `renderToStaticMarkup`

I opted not to add the stream-based methods at this time (mostly cause I don't feel like typing the streams), but I can do that if it is desired.