### PR TITLE
Events: Expose clipboardData

### DIFF
--- a/src/React/Basic/DOM/Events.purs
+++ b/src/React/Basic/DOM/Events.purs
@@ -41,6 +41,7 @@ module React.Basic.DOM.Events
   , clientY
   , button
   , buttons
+  , clipboardData
   ) where
 
 import Prelude


### PR DESCRIPTION
I noticed randomly that `clipboardData` is defined, but not exposed.