### PR TITLE
Events: Adds dataTransfers

### DIFF
--- a/src/React/Basic/DOM/Events.purs
+++ b/src/React/Basic/DOM/Events.purs
@@ -41,6 +41,7 @@ module React.Basic.DOM.Events
   , clientY
   , button
   , buttons
+  , dataTransfer
   ) where
 
 import Prelude
@@ -180,6 +181,10 @@ button = unsafeEventFn \e -> toMaybe (unsafeCoerce e).button
 
 buttons :: EventFn SyntheticEvent (Maybe Int)
 buttons = unsafeEventFn \e -> toMaybe (unsafeCoerce e).buttons
+
+-- | Drag event fields
+dataTransfer :: EventFn SyntheticEvent (Maybe DataTransfer)
+dataTransfer = unsafeEventFn \e -> toMaybe (unsafeCoerce e).dataTransfer
 
 -- \ Shared keyboard + mouse fields
 ctrlKey :: EventFn SyntheticEvent (Maybe Boolean)


### PR DESCRIPTION
Noticed `dataTransfer` is missing for drag events. It's comparable to `clipboardData`.

TypeScript Definition containing `dataTransfer`:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/a13fa7abf55daedf25b31258b908548f55962c7a/react/index.d.ts#L300