### PR TITLE
Fix import path in React.Basic.DOM.Server JS

### DIFF
--- a/src/React/Basic/DOM/Server.js
+++ b/src/React/Basic/DOM/Server.js
@@ -1,3 +1,3 @@
-import ReactDOMServer from "react-dom/server";
+import ReactDOMServer from "react-dom/server.js";
 export var renderToString = ReactDOMServer.renderToString;
 export var renderToStaticMarkup = ReactDOMServer.renderToStaticMarkup;


### PR DESCRIPTION
The string in import statement in Server.js is a path and it requires the file suffix as well.