### PR TITLE
Update Concurrent.js

### DIFF
--- a/src/React/Basic/DOM/Concurrent.js
+++ b/src/React/Basic/DOM/Concurrent.js
@@ -1,14 +1,14 @@
 import ReactDOM from "react-dom";
-const createRoot = ReactDOM.createRoot || ReactDOM.unstable_createRoot;
-const createBlockingRoot =
+const createRoot_ = ReactDOM.createRoot || ReactDOM.unstable_createRoot;
+const createBlockingRoot_ =
   ReactDOM.createBlockingRoot || ReactDOM.unstable_createBlockingRoot;
 
 export function createRoot(element) {
-  return () => createRoot(element);
+  return () => createRoot_(element);
 }
 
 export function createBlockingRoot(element) {
-  return () => createBlockingRoot(element);
+  return () => createBlockingRoot_(element);
 }
 
 export function renderRoot(root) {

--- a/src/React/Basic/DOM/Concurrent.js
+++ b/src/React/Basic/DOM/Concurrent.js
@@ -1,4 +1,4 @@
-import ReactDOM from "react-dom";
+import ReactDOM from "react-dom/client";
 const createRoot_ = ReactDOM.createRoot || ReactDOM.unstable_createRoot;
 const createBlockingRoot_ =
   ReactDOM.createBlockingRoot || ReactDOM.unstable_createBlockingRoot;

--- a/src/React/Basic/DOM/Server.js
+++ b/src/React/Basic/DOM/Server.js
@@ -1,3 +1,3 @@
-import ReactDOMServer from "react-dom/server.js";
+import ReactDOMServer from "react-dom/server";
 export var renderToString = ReactDOMServer.renderToString;
 export var renderToStaticMarkup = ReactDOMServer.renderToStaticMarkup;


### PR DESCRIPTION
```
✘ [ERROR] The symbol "createRoot" has already been declared

    output/React.Basic.DOM.Concurrent/foreign.js:6:16:
      6 │ export function createRoot(element) {
        ╵                 ~~~~~~~~~~

  The symbol "createRoot" was originally declared here:

    output/React.Basic.DOM.Concurrent/foreign.js:2:6:
      2 │ const createRoot = ReactDOM.createRoot || ReactDOM.unstable_createRoot;
        ╵       ~~~~~~~~~~
```